### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/doi2bib.sh
+++ b/doi2bib.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-curl -LH "Accept: application/x-bibtex;q=1" http://dx.doi.org/$1
+curl -LH "Accept: application/x-bibtex;q=1" https://doi.org/$1
 echo


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!