### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/doi2bib.sh
+++ b/doi2bib.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-curl -LH "Accept: application/x-bibtex;q=1" http://dx.doi.org/$1
+curl -LH "Accept: application/x-bibtex;q=1" https://doi.org/$1
 echo


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and query the resolver securely.

Cheers!